### PR TITLE
Fixes the HTTP/1.1 417 Expectation Failed Bug

### DIFF
--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -955,6 +955,7 @@ class WordpressClient
         curl_setopt($ch, CURLOPT_POSTFIELDS, $this->request);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_USERAGENT, $this->userAgent);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Expect:')); //Fixes the HTTP/1.1 417 Expectation Failed Bug
         if ($this->proxyConfig != false) {
             if (isset($this->proxyConfig['proxy_ip'])) {
                 curl_setopt($ch, CURLOPT_PROXY, $this->proxyConfig['proxy_ip']);


### PR DESCRIPTION
Fixes the "Expect: 100-continue" issue on some endpoints. Error example: 

> Uncaught Network error:
> Expectation Failed
> The expectation given in the Expect request-header field could not be met by this server. The client sent
> 
>    Expect: 100-continue
> Only the 100-continue expectation is supported.
> 
> (Code: 417) thrown in /var/www/html/vendor/hieu-le/wordpress-xmlrpc-client/src/WordpressClient.php on line 999